### PR TITLE
Fix gDrive stream out of memory issue and unbounded pressure graph me…

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -9,6 +9,7 @@ const {
   ccsGraphA,
   ccsGraphB,
   ccsGraphC,
+  clearPressureGraph,
   getGraphMetadata,
 } = require('./services/graphs');
 const { renderDashboard } = require('./views/dashboard');
@@ -148,21 +149,14 @@ function registerRoutes(app) {
       return res.status(500).json({ error: msg.trim() });
     }
 
-    longTermPressureGraph.fullXVals.length = 0;
-    longTermPressureGraph.fullYVals.length = 0;
-    longTermPressureGraph.displayXVals.length = 0;
-    longTermPressureGraph.displayYVals.length = 0;
-
-    shortTermPressureGraph.fullXVals.length = 0;
-    shortTermPressureGraph.fullYVals.length = 0;
-    shortTermPressureGraph.displayXVals.length = 0;
-    shortTermPressureGraph.displayYVals.length = 0;
+    clearPressureGraph(longTermPressureGraph);
+    clearPressureGraph(shortTermPressureGraph);
 
     console.log('Experiment reset: long_term_logs and short_term_logs cleared.');
     return res.status(200).json({ success: true });
   });
 
-  // Raw reversed log file
+  // Raw cached recent log snippet
   app.get('/raw', async (req, res) => {
     try {
       if (fs.existsSync(REVERSED_FILE_PATH)) {

--- a/services/gdrive.js
+++ b/services/gdrive.js
@@ -3,6 +3,144 @@ const https = require('https');
 const { drive, FOLDER_ID, API_KEY, REVERSED_FILE_PATH } = require('../config');
 const state = require('./state');
 
+const RECENT_LOG_WINDOW_MS = 30 * 60 * 1000;
+const MAX_SNIPPET_LINES = 10_000;
+const FALLBACK_SNIPPET_LINES = 5_000;
+const MAX_SNIPPET_BYTES = 2 * 1024 * 1024;
+
+function normalizeTimestampCandidate(candidate) {
+  if (!candidate) {
+    return null;
+  }
+
+  const isoLikeMatch = candidate.match(
+    /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)$/
+  );
+  if (isoLikeMatch) {
+    return `${isoLikeMatch[1]}T${isoLikeMatch[2]}`;
+  }
+
+  return candidate;
+}
+
+function parseDisplayLogTimestampMs(line) {
+  if (typeof line !== 'string' || line.length === 0) {
+    return null;
+  }
+
+  const patterns = [
+    /\b(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)\b/,
+    /\b(\d{1,2}\/\d{1,2}\/\d{4}[ T]\d{1,2}:\d{2}:\d{2}(?:\s?(?:AM|PM))?)\b/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = line.match(pattern);
+    if (!match) {
+      continue;
+    }
+
+    const parsed = Date.parse(normalizeTimestampCandidate(match[1]));
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function createDisplayLogSnippetCollector(options = {}) {
+  const recentWindowMs = options.recentWindowMs ?? RECENT_LOG_WINDOW_MS;
+  const maxLines = options.maxLines ?? MAX_SNIPPET_LINES;
+  const fallbackLines = options.fallbackLines ?? FALLBACK_SNIPPET_LINES;
+  const maxBytes = options.maxBytes ?? MAX_SNIPPET_BYTES;
+
+  const records = [];
+  let totalBytes = 0;
+  let newestTimestampMs = null;
+
+  function removeFirstRecord() {
+    if (records.length === 0) {
+      return;
+    }
+
+    const removed = records.shift();
+    totalBytes -= removed.byteLength;
+  }
+
+  function trimToRecentWindow() {
+    if (newestTimestampMs == null) {
+      return;
+    }
+
+    const oldestAllowedMs = newestTimestampMs - recentWindowMs;
+
+    while (records.length > 0) {
+      const firstTimestampMs = records[0].timestampMs;
+
+      if (firstTimestampMs != null) {
+        if (firstTimestampMs < oldestAllowedMs) {
+          removeFirstRecord();
+          continue;
+        }
+        break;
+      }
+
+      const nextTimestampIndex = records.findIndex((record, index) => index > 0 && record.timestampMs != null);
+      if (nextTimestampIndex === -1) {
+        break;
+      }
+
+      const nextTimestampMs = records[nextTimestampIndex].timestampMs;
+      if (nextTimestampMs == null || nextTimestampMs < oldestAllowedMs) {
+        removeFirstRecord();
+        continue;
+      }
+
+      removeFirstRecord();
+    }
+  }
+
+  function trimToSafetyCaps() {
+    const preferredLineLimit = newestTimestampMs == null ? fallbackLines : maxLines;
+
+    while (records.length > preferredLineLimit || totalBytes > maxBytes) {
+      removeFirstRecord();
+    }
+  }
+
+  return {
+    appendLine(line) {
+      const timestampMs = parseDisplayLogTimestampMs(line);
+      if (timestampMs != null && (newestTimestampMs == null || timestampMs > newestTimestampMs)) {
+        newestTimestampMs = timestampMs;
+      }
+
+      const byteLength = Buffer.byteLength(line, 'utf8') + 1;
+      records.push({ line, timestampMs, byteLength });
+      totalBytes += byteLength;
+
+      trimToRecentWindow();
+      trimToSafetyCaps();
+    },
+    finalize() {
+      return {
+        lines: records.map((record) => record.line).reverse(),
+        byteLength: totalBytes,
+        lineCount: records.length,
+        newestTimestampMs,
+      };
+    },
+  };
+}
+
+function collectRecentLogSnippet(lines, options = {}) {
+  const collector = createDisplayLogSnippetCollector(options);
+  for (const line of lines) {
+    collector.appendLine(line);
+  }
+  return collector.finalize();
+}
+
 /**
  * Fetch the most recent plain-text log files from Google Drive.
  * Returns { displayFile } where displayFile may be null.
@@ -33,10 +171,17 @@ async function getMostRecentFile() {
 }
 
 /**
- * Stream-downloads a text file from Google Drive and returns its lines.
+ * Stream-downloads a text file from Google Drive and returns a bounded recent snippet.
  */
-async function fetchFileContents(fileId) {
+async function fetchRecentLogSnippet(fileId, options = {}) {
   let retries = 3;
+  const logger = options.logger ?? console;
+  const collectorOptions = {
+    recentWindowMs: options.recentWindowMs,
+    maxLines: options.maxLines,
+    fallbackLines: options.fallbackLines,
+    maxBytes: options.maxBytes,
+  };
 
   while (retries > 0) {
     try {
@@ -56,20 +201,22 @@ async function fetchFileContents(fileId) {
           .on('error', reject);
       });
 
-      const lines = [];
+      const collector = createDisplayLogSnippetCollector(collectorOptions);
       let currentLine = '';
 
       await new Promise((resolve, reject) => {
         response.on('data', chunk => {
-          const chunkStr   = chunk.toString();
+          const chunkStr = chunk.toString('utf8');
           const chunkLines = (currentLine + chunkStr).split('\n');
           currentLine = chunkLines.pop();
-          lines.push(...chunkLines);
+          for (const line of chunkLines) {
+            collector.appendLine(line);
+          }
         });
 
         response.on('end', () => {
-          if (currentLine){
-            lines.push(currentLine);
+          if (currentLine) {
+            collector.appendLine(currentLine);
           }
           resolve();
         });
@@ -77,11 +224,11 @@ async function fetchFileContents(fileId) {
         response.on('error', reject);
       });
 
-      return lines;
+      return collector.finalize();
 
     } catch (err) {
       retries--;
-      console.log(`Retry attempt ${4 - retries}: ${err.message}`);
+      logger.log(`Retry attempt ${4 - retries}: ${err.message}`);
       if (retries === 0) return false;
     }
   }
@@ -109,7 +256,7 @@ function writeToFile(lines) {
     }
 
     writeStream.on('finish', async () => {
-      console.log('Reversed log updated successfully.');
+      console.log('Recent log snippet updated successfully.');
       resolve(true);
     });
 
@@ -123,50 +270,72 @@ function writeToFile(lines) {
 }
 
 /**
- * Fetch display log from Google Drive, reverse it, and write to local file.
+ * Fetch display log from Google Drive, extract a bounded recent snippet, and write it to local file.
  */
-async function fetchDisplayFileContents() {
+async function fetchDisplayFileContents(options = {}) {
+  const logger = options.logger ?? console;
+  const stateRef = options.stateRef ?? state;
+  const getMostRecentFileFn = options.getMostRecentFileFn ?? getMostRecentFile;
+  const fetchRecentLogSnippetFn = options.fetchRecentLogSnippetFn ?? fetchRecentLogSnippet;
+  const writeToFileFn = options.writeToFileFn ?? writeToFile;
+
   try {
-    const { displayFile } = await getMostRecentFile();
+    const { displayFile } = await getMostRecentFileFn();
 
     if (!displayFile) {
-      console.log("No display file found!");
+      logger.log("No display file found!");
       return false;
     }
 
-    console.log("Fetching new display log file...");
-    let displayLines = null;
-    try {
-      displayLines = await fetchFileContents(displayFile.id);
-      if (!Array.isArray(displayLines)) {
-        console.warn("Display File fetch failed or returned no lines. Skipping extraction.");
-        return false;
-      }
-      displayLines.reverse();
-      displayLines = displayLines.slice(0, 100000);
-    } catch (e) {
-      console.error("Log file failed:", e);
+    if (
+      stateRef.displayLogFileId === displayFile.id &&
+      stateRef.displayLogLastModified === displayFile.modifiedTime
+    ) {
+      logger.log('Display log unchanged, using cached recent snippet.');
+      return true;
     }
 
-    const writePromise = writeToFile(displayLines);
+    logger.log("Fetching new display log file...");
+    let snippet = null;
+    try {
+      snippet = await fetchRecentLogSnippetFn(displayFile.id, options);
+      if (!snippet || !Array.isArray(snippet.lines)) {
+        logger.warn("Display log fetch failed or returned no lines. Skipping extraction.");
+        return false;
+      }
+    } catch (e) {
+      logger.error("Log file failed:", e);
+      return false;
+    }
+
+    const writePromise = writeToFileFn(snippet.lines);
     const [writeResult] = await Promise.allSettled([writePromise]);
 
     if (writeResult.status === 'fulfilled') {
-      console.log("File write complete.");
-      state.displayLogLastModified = displayFile.modifiedTime;
+      logger.log("File write complete.");
+      stateRef.displayLogLastModified = displayFile.modifiedTime;
+      stateRef.displayLogFileId = displayFile.id;
+      return true;
     } else {
-      console.error("File write failed:", writeResult.reason);
+      logger.error("File write failed:", writeResult.reason);
+      return false;
     }
-
   } catch (err) {
-    console.error(`Error processing file: ${err.message}`);
+    logger.error(`Error processing file: ${err.message}`);
     return false;
   }
 }
 
 module.exports = {
+  RECENT_LOG_WINDOW_MS,
+  MAX_SNIPPET_LINES,
+  FALLBACK_SNIPPET_LINES,
+  MAX_SNIPPET_BYTES,
+  parseDisplayLogTimestampMs,
+  createDisplayLogSnippetCollector,
+  collectRecentLogSnippet,
   getMostRecentFile,
-  fetchFileContents,
+  fetchRecentLogSnippet,
   writeToFile,
   fetchDisplayFileContents,
 };

--- a/services/graphs.js
+++ b/services/graphs.js
@@ -115,9 +115,10 @@ function appendPressurePoint(graph, tSec, pressure) {
   graph.fullXVals.push(tSec);
   graph.fullYVals.push(pressure);
 
-  if (graph.fullXVals.length > graph.maxDataPoints) {
-    graph.fullXVals = graph.fullXVals.slice(-graph.maxDataPoints);
-    graph.fullYVals = graph.fullYVals.slice(-graph.maxDataPoints);
+  const overflowCount = graph.fullXVals.length - graph.maxDataPoints;
+  if (overflowCount > 0) {
+    graph.fullXVals.splice(0, overflowCount);
+    graph.fullYVals.splice(0, overflowCount);
     rebuildDisplayData(graph);
     return;
   }

--- a/services/graphs.js
+++ b/services/graphs.js
@@ -14,6 +14,15 @@ function createGraphObj(options = {}) {
   };
 }
 
+function resetPressureGraphDisplayState(graph) {
+  graph.displayXVals.length = 0;
+  graph.displayYVals.length = 0;
+  graph.lastUsedFactor = 1;
+  graph.lastPermanentIndex = -1;
+  graph.chartDataIntervalCount = 0;
+  graph.chartDataIntervalDuration = 1;
+}
+
 const shortTermPressureGraph = createGraphObj({
   maxDataPoints: 30000,
   maxDisplayPoints: 1024,
@@ -27,6 +36,10 @@ const longTermPressureGraph = createGraphObj({
 
 function updateDisplayData(graph) {
   const len = graph.fullXVals.length;
+  if (len === 0) {
+    resetPressureGraphDisplayState(graph);
+    return;
+  }
 
   const predictedPoints = Math.ceil((len - 1) / graph.lastUsedFactor) + 1;
 
@@ -63,6 +76,61 @@ function updateDisplayData(graph) {
   }
 }
 
+function rebuildDisplayData(graph) {
+  const len = graph.fullXVals.length;
+  resetPressureGraphDisplayState(graph);
+
+  if (len === 0) {
+    return;
+  }
+
+  let downsampleFactor = 1;
+  let predictedPoints = len;
+
+  while (predictedPoints > graph.maxDisplayPoints) {
+    downsampleFactor *= 2;
+    predictedPoints = Math.ceil((len - 1) / downsampleFactor) + 1;
+  }
+
+  graph.lastUsedFactor = downsampleFactor;
+
+  if (downsampleFactor === 1) {
+    graph.displayXVals.push(...graph.fullXVals);
+    graph.displayYVals.push(...graph.fullYVals);
+    graph.lastPermanentIndex = len - 2;
+    return;
+  }
+
+  for (let i = 0; i < len - 1; i += downsampleFactor) {
+    graph.displayXVals.push(graph.fullXVals[i]);
+    graph.displayYVals.push(graph.fullYVals[i]);
+    graph.lastPermanentIndex = i;
+  }
+
+  graph.displayXVals.push(graph.fullXVals[len - 1]);
+  graph.displayYVals.push(graph.fullYVals[len - 1]);
+}
+
+function appendPressurePoint(graph, tSec, pressure) {
+  graph.fullXVals.push(tSec);
+  graph.fullYVals.push(pressure);
+
+  if (graph.fullXVals.length > graph.maxDataPoints) {
+    graph.fullXVals = graph.fullXVals.slice(-graph.maxDataPoints);
+    graph.fullYVals = graph.fullYVals.slice(-graph.maxDataPoints);
+    rebuildDisplayData(graph);
+    return;
+  }
+
+  updateDisplayData(graph);
+}
+
+function clearPressureGraph(graph) {
+  graph.fullXVals.length = 0;
+  graph.fullYVals.length = 0;
+  resetPressureGraphDisplayState(graph);
+}
+
 function getGraphMetadata(graph) {
   return {
     rawPointCount: graph.fullXVals.length,
@@ -93,7 +161,11 @@ const ccsGraphC = createCCSGraphObj();
 
 module.exports = {
   createGraphObj,
+  resetPressureGraphDisplayState,
   updateDisplayData,
+  rebuildDisplayData,
+  appendPressurePoint,
+  clearPressureGraph,
   getGraphMetadata,
   shortTermPressureGraph,
   longTermPressureGraph,

--- a/services/polling.js
+++ b/services/polling.js
@@ -11,7 +11,7 @@ const { fetchDisplayFileContents } = require('./gdrive');
 const {
   shortTermPressureGraph,
   longTermPressureGraph,
-  updateDisplayData,
+  appendPressurePoint,
   addCCSPoint,
   ccsGraphA,
   ccsGraphB,
@@ -106,7 +106,7 @@ function applyShortTermEntries(entries, options = {}) {
   const {
     stateRef = state,
     graph = shortTermPressureGraph,
-    graphUpdater = updateDisplayData,
+    pressurePointAppender = appendPressurePoint,
     ccsA = ccsGraphA,
     ccsB = ccsGraphB,
     ccsC = ccsGraphC,
@@ -167,9 +167,7 @@ function applyShortTermEntries(entries, options = {}) {
       continue;
     }
 
-    graph.fullXVals.push(tSec);
-    graph.fullYVals.push(pressure);
-    graphUpdater(graph);
+    pressurePointAppender(graph, tSec, pressure);
 
     summary.appendedCount++;
     stateRef.lastShortTermCursor = entryCursor;
@@ -186,7 +184,7 @@ function applyLongTermEntries(entries, options = {}) {
   const {
     stateRef = state,
     graph = longTermPressureGraph,
-    graphUpdater = updateDisplayData,
+    pressurePointAppender = appendPressurePoint,
     logger = console,
     expectedIntervalMs = LONG_TERM_EXPECTED_INTERVAL_MS,
   } = options;
@@ -243,9 +241,7 @@ function applyLongTermEntries(entries, options = {}) {
     }
 
     const tSec = Math.floor(entryMs / 1000);
-    graph.fullXVals.push(tSec);
-    graph.fullYVals.push(pressure);
-    graphUpdater(graph);
+    pressurePointAppender(graph, tSec, pressure);
 
     summary.appendedCount++;
     stateRef.lastLongTermCursor = entryCursor;

--- a/services/state.js
+++ b/services/state.js
@@ -4,6 +4,7 @@ const state = {
   lastModifiedTime: null,
   webMonitorLastModified: null,
   displayLogLastModified: null,
+  displayLogFileId: null,
   experimentRunning: false,
   lastShortTermCursor: null,
   lastLongTermCursor: null,

--- a/services/supabase.js
+++ b/services/supabase.js
@@ -1,6 +1,6 @@
 const { supabase } = require('../config');
 const state = require('./state');
-const { updateDisplayData, addCCSPoint } = require('./graphs');
+const { appendPressurePoint, addCCSPoint } = require('./graphs');
 
 const PAGE_SIZE = 1000;
 
@@ -182,15 +182,12 @@ async function backfillShortTermGraph(graph) {
         const pressure = row.data?.pressure;
         if (pressure == null) continue;
         const tSec = Math.floor(new Date(row.created_at).getTime() / 1000);
-        graph.fullXVals.push(tSec);
-        graph.fullYVals.push(parseFloat(pressure));
-        updateDisplayData(graph);
+        appendPressurePoint(graph, tSec, parseFloat(pressure));
       }
 
       lastCursor = buildCursorFromRow(data[data.length - 1], 'created_at');
 
       if (data.length < PAGE_SIZE) break;
-      if (graph.fullXVals.length >= graph.maxDataPoints) break;
       from += PAGE_SIZE;
     }
 
@@ -234,15 +231,12 @@ async function backfillLongTermGraph(graph) {
       for (const row of data) {
         if (row.avg_pressure == null) continue;
         const tSec = Math.floor(new Date(row.recorded_at).getTime() / 1000);
-        graph.fullXVals.push(tSec);
-        graph.fullYVals.push(row.avg_pressure);
-        updateDisplayData(graph);
+        appendPressurePoint(graph, tSec, row.avg_pressure);
       }
 
       lastCursor = buildCursorFromRow(data[data.length - 1], 'recorded_at');
 
       if (data.length < PAGE_SIZE) break;
-      if (graph.fullXVals.length >= graph.maxDataPoints) break;
       from += PAGE_SIZE;
     }
 

--- a/test/polling.test.js
+++ b/test/polling.test.js
@@ -259,6 +259,7 @@ const state = require('../services/state');
 const registerRoutes = require('../routes');
 const {
   createGraphObj,
+  appendPressurePoint,
   shortTermPressureGraph,
   longTermPressureGraph,
   ccsGraphA,
@@ -359,6 +360,33 @@ function resetPressureGraph(graph) {
 function resetCCSGraph(graph) {
   graph.xVals.length = 0;
   graph.yVals.length = 0;
+}
+
+function assertPressureGraphDisplayIntegrity(graph) {
+  assert.equal(
+    graph.displayXVals.length,
+    graph.displayYVals.length,
+    'expected pressure display x/y arrays to stay aligned'
+  );
+  assert.ok(
+    graph.displayXVals.length <= graph.maxDisplayPoints,
+    `expected display points to stay within cap, got ${graph.displayXVals.length}`
+  );
+
+  for (let index = 1; index < graph.displayXVals.length; index++) {
+    assert.ok(
+      graph.displayXVals[index] > graph.displayXVals[index - 1],
+      `expected strictly increasing display x values at index ${index}`
+    );
+  }
+
+  if (graph.fullXVals.length === 0) {
+    assert.equal(graph.displayXVals.length, 0);
+    return;
+  }
+
+  assert.equal(graph.displayXVals.at(-1), graph.fullXVals.at(-1));
+  assert.equal(graph.displayYVals.at(-1), graph.fullYVals.at(-1));
 }
 
 function resetSingletonState() {
@@ -947,6 +975,29 @@ test('applyShortTermEntries caps raw points at maxDataPoints and keeps the newes
     entries.slice(-5).map((entry) => Math.floor(Date.parse(entry.created_at) / 1000))
   );
   assert.equal(graph.displayXVals.at(-1), Math.floor(Date.parse(entries.at(-1).created_at) / 1000));
+  assertPressureGraphDisplayIntegrity(graph);
+});
+
+test('appendPressurePoint preserves graph array references and display invariants after repeated cap trims', () => {
+  const graph = createGraphObj({
+    maxDataPoints: 5,
+    maxDisplayPoints: 4,
+    sourceResolutionLabel: '~3s source data',
+  });
+  const fullXRef = graph.fullXVals;
+  const fullYRef = graph.fullYVals;
+
+  for (let index = 0; index < 12; index++) {
+    appendPressurePoint(graph, 1_000 + index, index);
+
+    assert.strictEqual(graph.fullXVals, fullXRef);
+    assert.strictEqual(graph.fullYVals, fullYRef);
+    assert.ok(graph.fullXVals.length <= graph.maxDataPoints);
+    assertPressureGraphDisplayIntegrity(graph);
+  }
+
+  assert.deepEqual(graph.fullXVals, [1007, 1008, 1009, 1010, 1011]);
+  assert.deepEqual(graph.fullYVals, [7, 8, 9, 10, 11]);
 });
 
 test('long-term data remains capped at the lower historical display density', () => {
@@ -992,6 +1043,7 @@ test('applyLongTermEntries caps raw points at maxDataPoints and keeps the newest
     entries.slice(-5).map((entry) => Math.floor(Date.parse(entry.recorded_at) / 1000))
   );
   assert.equal(graph.displayXVals.at(-1), Math.floor(Date.parse(entries.at(-1).recorded_at) / 1000));
+  assertPressureGraphDisplayIntegrity(graph);
 });
 
 test('chart-data returns density metadata for both short and long views', () => {
@@ -1053,6 +1105,13 @@ test('dashboard HTML uses the recent-log viewer and does not force refresh on op
   assert.equal(response.statusCode, 200);
   assert.match(response.payload, /Recent Log \(last 30 min\)/);
   assert.match(response.payload, /Show Recent Log/);
+  assert.match(response.payload, /class="log-viewer-header"/);
+  assert.match(response.payload, /class="btn-toggle log-toggle-button"/);
+  assert.match(response.payload, /class="btn-toggle pressure-toggle-button"/);
+  assert.match(response.payload, /chartEl\.getBoundingClientRect\(\)\.width/);
+  assert.match(response.payload, /overflow:\s*hidden;/);
   assert.match(response.payload, /fetch\('\/raw'\)/);
   assert.doesNotMatch(response.payload, /fetch\('\/refresh-display'\)/);
+  assert.doesNotMatch(response.payload, /margin-top:\s*-3\.5em/);
+  assert.doesNotMatch(response.payload, /float:\s*right/);
 });

--- a/test/polling.test.js
+++ b/test/polling.test.js
@@ -259,7 +259,6 @@ const state = require('../services/state');
 const registerRoutes = require('../routes');
 const {
   createGraphObj,
-  updateDisplayData,
   shortTermPressureGraph,
   longTermPressureGraph,
   ccsGraphA,
@@ -268,6 +267,7 @@ const {
 } = require('../services/graphs');
 const {
   backfillShortTermGraph,
+  backfillLongTermGraph,
   fetchShortTermEntriesSince,
   fetchLongTermEntriesSince,
 } = require('../services/supabase');
@@ -277,6 +277,14 @@ const {
   fetchAndUpdateFile,
   pollLongTerm,
 } = require('../services/polling');
+const {
+  FALLBACK_SNIPPET_LINES,
+  MAX_SNIPPET_BYTES,
+  MAX_SNIPPET_LINES,
+  RECENT_LOG_WINDOW_MS,
+  collectRecentLogSnippet,
+  fetchDisplayFileContents,
+} = require('../services/gdrive');
 
 function createLogger() {
   const logs = [];
@@ -358,6 +366,7 @@ function resetSingletonState() {
   state.lastLongTermCursor = null;
   state.webMonitorLastModified = null;
   state.displayLogLastModified = null;
+  state.displayLogFileId = null;
   state.experimentRunning = false;
   state.data = {
     pressure: null,
@@ -398,8 +407,13 @@ function createResponseRecorder() {
   return {
     statusCode: 200,
     payload: null,
+    contentType: null,
     status(code) {
       this.statusCode = code;
+      return this;
+    },
+    type(value) {
+      this.contentType = value;
       return this;
     },
     json(body) {
@@ -436,7 +450,6 @@ test('applyShortTermEntries catches up every unseen short-term row in order', ()
   const summary = applyShortTermEntries(entries, {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     ccsA,
     ccsB,
     ccsC,
@@ -478,7 +491,6 @@ test('applyShortTermEntries skips malformed pressure rows but still advances the
   const summary = applyShortTermEntries(entries, {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     ccsA,
     ccsB,
     ccsC,
@@ -511,7 +523,6 @@ test('applyLongTermEntries drains missed long-term rows in order', () => {
   const summary = applyLongTermEntries(entries, {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     logger,
   });
 
@@ -541,14 +552,12 @@ test('applyLongTermEntries ignores stale long-term rows that were already covere
   applyLongTermEntries(entries.slice(0, 2), {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     logger,
   });
 
   const summary = applyLongTermEntries(entries, {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     logger,
   });
 
@@ -665,6 +674,117 @@ test('fetchAndUpdateFile only catches up fresh rows after a stale baseline seeds
   assert.equal(state.webMonitorLastModified?.toISOString(), freshEntries.at(-1).created_at);
 });
 
+test('collectRecentLogSnippet keeps the newest timestamped window newest-first', () => {
+  const lines = [
+    '2026-03-26 07:20:00 old event',
+    '2026-03-26 07:31:00 keep earliest',
+    'detail line for the 07:31 event',
+    '2026-03-26 07:45:00 keep later',
+    '2026-03-26 08:00:00 newest event',
+  ];
+
+  const snippet = collectRecentLogSnippet(lines, {
+    recentWindowMs: RECENT_LOG_WINDOW_MS,
+  });
+
+  assert.deepEqual(snippet.lines, [
+    '2026-03-26 08:00:00 newest event',
+    '2026-03-26 07:45:00 keep later',
+    'detail line for the 07:31 event',
+    '2026-03-26 07:31:00 keep earliest',
+  ]);
+  assert.equal(snippet.lineCount, 4);
+  assert.equal(snippet.newestTimestampMs, Date.parse('2026-03-26T08:00:00'));
+});
+
+test('collectRecentLogSnippet falls back to the last 5000 lines without timestamps', () => {
+  const totalLines = FALLBACK_SNIPPET_LINES + 25;
+  const lines = Array.from({ length: totalLines }, (_, index) => `line ${index}`);
+
+  const snippet = collectRecentLogSnippet(lines);
+
+  assert.equal(snippet.lineCount, FALLBACK_SNIPPET_LINES);
+  assert.equal(snippet.lines[0], `line ${totalLines - 1}`);
+  assert.equal(snippet.lines.at(-1), 'line 25');
+  assert.equal(snippet.newestTimestampMs, null);
+  assert.ok(snippet.lineCount <= MAX_SNIPPET_LINES);
+});
+
+test('collectRecentLogSnippet respects the byte cap for large unparseable logs', () => {
+  const largePayload = 'x'.repeat(2_048);
+  const lines = Array.from({ length: 2_000 }, (_, index) => `line-${index} ${largePayload}`);
+
+  const snippet = collectRecentLogSnippet(lines);
+
+  assert.ok(snippet.lineCount < FALLBACK_SNIPPET_LINES);
+  assert.ok(snippet.lineCount <= MAX_SNIPPET_LINES);
+  assert.ok(snippet.byteLength <= MAX_SNIPPET_BYTES);
+});
+
+test('fetchDisplayFileContents skips downloading an unchanged Drive file', async () => {
+  const { logger, logs } = createLogger();
+  state.displayLogFileId = 'file-1';
+  state.displayLogLastModified = '2026-03-26T08:00:00.000Z';
+  let fetchCallCount = 0;
+  let writeCallCount = 0;
+
+  const result = await fetchDisplayFileContents({
+    logger,
+    stateRef: state,
+    getMostRecentFileFn: async () => ({
+      displayFile: {
+        id: 'file-1',
+        modifiedTime: '2026-03-26T08:00:00.000Z',
+      },
+    }),
+    fetchRecentLogSnippetFn: async () => {
+      fetchCallCount++;
+      return { lines: ['newest line'] };
+    },
+    writeToFileFn: async () => {
+      writeCallCount++;
+      return true;
+    },
+  });
+
+  assert.equal(result, true);
+  assert.equal(fetchCallCount, 0);
+  assert.equal(writeCallCount, 0);
+  assert.ok(logs.some((line) => line.includes('Display log unchanged')));
+});
+
+test('fetchDisplayFileContents writes a recent snippet and stores the file metadata', async () => {
+  const { logger } = createLogger();
+  const stateRef = {
+    displayLogFileId: null,
+    displayLogLastModified: null,
+  };
+  let writtenLines = null;
+
+  const result = await fetchDisplayFileContents({
+    logger,
+    stateRef,
+    getMostRecentFileFn: async () => ({
+      displayFile: {
+        id: 'file-2',
+        modifiedTime: '2026-03-26T08:30:00.000Z',
+      },
+    }),
+    fetchRecentLogSnippetFn: async () => ({
+      lines: ['newest event', 'older event'],
+    }),
+    writeToFileFn: async (lines) => {
+      writtenLines = [...lines];
+      return true;
+    },
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(writtenLines, ['newest event', 'older event']);
+  assert.equal(stateRef.displayLogFileId, 'file-2');
+  assert.equal(stateRef.displayLogLastModified, '2026-03-26T08:30:00.000Z');
+});
+
 test('fetchShortTermEntriesSince paginates tied timestamps deterministically across pages', async () => {
   const entries = buildShortTermEntries(1_005);
   const boundaryTimestamp = entries[998].created_at;
@@ -747,8 +867,32 @@ test('fetchLongTermEntriesSince resumes within a tied timestamp using the id cur
   );
 });
 
+test('backfillLongTermGraph retains the newest points within the configured cap', async () => {
+  const graph = createGraphObj({
+    maxDataPoints: 5,
+    maxDisplayPoints: 4,
+    sourceResolutionLabel: '1-min averaged source data',
+  });
+  const entries = buildLongTermEntries(8);
+  setSupabaseTableRows('long_term_logs', entries);
+
+  const lastCursor = await backfillLongTermGraph(graph);
+
+  assert.deepEqual(lastCursor, {
+    timestamp: entries.at(-1).recorded_at,
+    id: entries.at(-1).id,
+  });
+  assert.equal(graph.fullXVals.length, 5);
+  assert.deepEqual(
+    graph.fullXVals,
+    entries.slice(-5).map((entry) => Math.floor(Date.parse(entry.recorded_at) / 1000))
+  );
+  assert.equal(graph.displayXVals.at(-1), Math.floor(Date.parse(entries.at(-1).recorded_at) / 1000));
+});
+
 test('24-hour short-term data keeps a denser live display than the old 256-point cap', () => {
   const graph = createGraphObj({
+    maxDataPoints: 30_000,
     maxDisplayPoints: 1024,
     sourceResolutionLabel: '~3s source data',
   });
@@ -762,7 +906,6 @@ test('24-hour short-term data keeps a denser live display than the old 256-point
   applyShortTermEntries(entries, {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     ccsA,
     ccsB,
     ccsC,
@@ -775,8 +918,40 @@ test('24-hour short-term data keeps a denser live display than the old 256-point
   assert.ok(graph.displayXVals.length <= 1024);
 });
 
+test('applyShortTermEntries caps raw points at maxDataPoints and keeps the newest rows', () => {
+  const graph = createGraphObj({
+    maxDataPoints: 5,
+    maxDisplayPoints: 4,
+    sourceResolutionLabel: '~3s source data',
+  });
+  const ccsA = createCCSGraph();
+  const ccsB = createCCSGraph();
+  const ccsC = createCCSGraph();
+  const stateRef = { lastShortTermCursor: null };
+  const entries = buildShortTermEntries(8);
+  const { logger } = createLogger();
+
+  applyShortTermEntries(entries, {
+    stateRef,
+    graph,
+    ccsA,
+    ccsB,
+    ccsC,
+    ccsPointAdder: addCCSPointForTest,
+    logger,
+  });
+
+  assert.equal(graph.fullXVals.length, 5);
+  assert.deepEqual(
+    graph.fullXVals,
+    entries.slice(-5).map((entry) => Math.floor(Date.parse(entry.created_at) / 1000))
+  );
+  assert.equal(graph.displayXVals.at(-1), Math.floor(Date.parse(entries.at(-1).created_at) / 1000));
+});
+
 test('long-term data remains capped at the lower historical display density', () => {
   const graph = createGraphObj({
+    maxDataPoints: 100_000,
     maxDisplayPoints: 256,
     sourceResolutionLabel: '1-min averaged source data',
   });
@@ -787,13 +962,36 @@ test('long-term data remains capped at the lower historical display density', ()
   applyLongTermEntries(entries, {
     stateRef,
     graph,
-    graphUpdater: updateDisplayData,
     logger,
   });
 
   assert.equal(graph.lastUsedFactor, 8);
   assert.ok(graph.displayXVals.length >= 180 && graph.displayXVals.length <= 181);
   assert.ok(graph.displayXVals.length <= 256);
+});
+
+test('applyLongTermEntries caps raw points at maxDataPoints and keeps the newest rows', () => {
+  const graph = createGraphObj({
+    maxDataPoints: 5,
+    maxDisplayPoints: 4,
+    sourceResolutionLabel: '1-min averaged source data',
+  });
+  const stateRef = { lastLongTermCursor: null };
+  const entries = buildLongTermEntries(8);
+  const { logger } = createLogger();
+
+  applyLongTermEntries(entries, {
+    stateRef,
+    graph,
+    logger,
+  });
+
+  assert.equal(graph.fullXVals.length, 5);
+  assert.deepEqual(
+    graph.fullXVals,
+    entries.slice(-5).map((entry) => Math.floor(Date.parse(entry.recorded_at) / 1000))
+  );
+  assert.equal(graph.displayXVals.at(-1), Math.floor(Date.parse(entries.at(-1).recorded_at) / 1000));
 });
 
 test('chart-data returns density metadata for both short and long views', () => {
@@ -840,4 +1038,21 @@ test('chart-data returns density metadata for both short and long views', () => 
   assert.equal(longResponse.payload.sourceResolutionLabel, longTermPressureGraph.sourceResolutionLabel);
   assert.deepEqual(longResponse.payload.xVals, longTermPressureGraph.displayXVals);
   assert.deepEqual(longResponse.payload.yVals, longTermPressureGraph.displayYVals);
+});
+
+test('dashboard HTML uses the recent-log viewer and does not force refresh on open', async () => {
+  const app = createFakeApp();
+  registerRoutes(app);
+
+  const dashboardRoute = app.routes.find((route) => route.method === 'GET' && route.path === '/');
+  assert.ok(dashboardRoute, 'expected / route to be registered');
+
+  const response = createResponseRecorder();
+  await dashboardRoute.handler({}, response);
+
+  assert.equal(response.statusCode, 200);
+  assert.match(response.payload, /Recent Log \(last 30 min\)/);
+  assert.match(response.payload, /Show Recent Log/);
+  assert.match(response.payload, /fetch\('\/raw'\)/);
+  assert.doesNotMatch(response.payload, /fetch\('\/refresh-display'\)/);
 });

--- a/views/dashboard.js
+++ b/views/dashboard.js
@@ -967,15 +967,15 @@ function renderDashboard(opts) {
 
       <!-- Log Viewer -->
       <div class="env-section">
-        <h3 class="dashboard-subtitle env-title">System Logs; Last Update: <span id="display-last-updated">${
-            data.displayLogLastModified
-              ? new Date(data.displayLogLastModified).toLocaleString("en-US", {
+        <h3 class="dashboard-subtitle env-title">Recent Log (last 30 min); Last Update: <span id="display-last-updated">${
+            state.displayLogLastModified
+              ? new Date(state.displayLogLastModified).toLocaleString("en-US", {
                   hour12: true,
                   timeZone: "America/Chicago"
                 })
               : "N/A"
         }</span></h3>
-        <button id="toggleButton" class="btn-toggle">Show Full Log</button>
+        <button id="toggleButton" class="btn-toggle">Show Recent Log</button>
         <div id="fullContent" class="content-section">
           <pre></pre>
         </div>
@@ -988,14 +988,28 @@ function renderDashboard(opts) {
 
          const toggleButton = document.getElementById('toggleButton');
          const fullSection = document.getElementById('fullContent');
-         const pre = fullSection.querySelector('pre')
+          const pre = fullSection.querySelector('pre')
+
+         async function loadRecentLogSnippet() {
+          try {
+            const response = await fetch('/raw');
+            if (!response.ok) {
+              pre.textContent = 'No recent log snippet cached yet.';
+              return;
+            }
+
+            const text = await response.text();
+            pre.textContent = text || 'No recent log snippet cached yet.';
+          } catch (error) {
+            console.error('Failed to load recent log snippet:', error);
+            pre.textContent = 'Unable to load recent log snippet.';
+          }
+         }
 
          if (showingFull) {
-          fetch('/raw').then(resp => resp.text()).then(text => {
-          pre.textContent = text;
           fullSection.classList.add('active');
-          toggleButton.textContent = 'Collapse Log View';
-          });
+          toggleButton.textContent = 'Hide Recent Log';
+          loadRecentLogSnippet();
         }
 
         setInterval(async() => {
@@ -1142,15 +1156,13 @@ function renderDashboard(opts) {
 
         toggleButton.addEventListener('click', async () => {
           if (!showingFull) {
-            pre.textContent = ' Fetching file contents...';
+            pre.textContent = 'Loading recent log snippet...';
             fullSection.classList.add('active');
-            await fetch('/refresh-display');
-            const resp = await (await fetch('/raw')).text();
-            pre.textContent = resp;
-            toggleButton.textContent = 'Collapse Log View';
+            await loadRecentLogSnippet();
+            toggleButton.textContent = 'Hide Recent Log';
           } else {
             fullSection.classList.remove('active');
-            toggleButton.textContent = 'Show Full Log';
+            toggleButton.textContent = 'Show Recent Log';
           }
           showingFull = !showingFull;
           sessionStorage.setItem('showingFull', showingFull);

--- a/views/dashboard.js
+++ b/views/dashboard.js
@@ -370,9 +370,37 @@ function renderDashboard(opts) {
           font-size: 0.75em;
           border-radius: 5px;
           transition: background-color 0.3s ease;
-          float: right;
-          margin-top: -3.5em;
-          margin-bottom: 5px;
+          cursor: pointer;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .pressure-chart-toolbar {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 12px;
+          flex-wrap: wrap;
+          padding: 0 10px 8px;
+          width: 98%;
+          margin: 0 auto;
+        }
+        .pressure-toggle-button {
+          flex-shrink: 0;
+        }
+        .log-viewer-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 12px;
+          flex-wrap: wrap;
+        }
+        .log-viewer-title {
+          flex: 1 1 320px;
+          margin: 0;
+        }
+        .log-toggle-button {
+          flex-shrink: 0;
         }
         .btn-refresh {
           width: 22px;
@@ -449,6 +477,8 @@ function renderDashboard(opts) {
           padding: 10px;
           margin: 14px auto;
           width: 98%;
+          box-sizing: border-box;
+          overflow: hidden;
         }
 
         #ccs-charts-section .chart-container { margin: 0; width: 100%; }
@@ -699,11 +729,11 @@ function renderDashboard(opts) {
 
       <div id="chart-root-2"></div>
       <div id="pressure-chart-section">
-        <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 10px 8px; width: 98%; margin: 0 auto 0 auto;">
+        <div class="pressure-chart-toolbar">
           <span id="pressure-chart-label" style="color:#94a3b8; font-size:14px;">
             Short-Term (Last 24h, ~3s source data, downsampled for display)
           </span>
-          <button id="pressure-view-toggle" class="btn-toggle" style="float:none; margin:0;">
+          <button id="pressure-view-toggle" class="btn-toggle pressure-toggle-button">
             Switch to Historical View
           </button>
         </div>
@@ -737,9 +767,22 @@ function renderDashboard(opts) {
           container.appendChild(wrapper);
 
           const chartEl = wrapper.querySelector('.chart');
+          const getChartWidth = () => {
+            const measuredWidth = Math.floor(chartEl.getBoundingClientRect().width || chartEl.clientWidth || 0);
+            if (measuredWidth > 0) {
+              return measuredWidth;
+            }
+
+            const wrapperStyles = window.getComputedStyle(wrapper);
+            const horizontalPadding =
+              Number.parseFloat(wrapperStyles.paddingLeft || '0') +
+              Number.parseFloat(wrapperStyles.paddingRight || '0');
+
+            return Math.max(1, Math.floor(wrapper.clientWidth - horizontalPadding));
+          };
 
           const uplot = new uPlot({
-            width: wrapper.clientWidth,
+            width: getChartWidth(),
             height: 300,
             series: [
               {},
@@ -784,8 +827,7 @@ function renderDashboard(opts) {
           }, data, chartEl);
 
           window.addEventListener('resize', () => {
-            const newWidth = wrapper.clientWidth;
-            uplot.setSize({ width: newWidth, height: 300 });
+            uplot.setSize({ width: getChartWidth(), height: 300 });
           });
 
           chartEl.ondblclick = () => {
@@ -967,15 +1009,17 @@ function renderDashboard(opts) {
 
       <!-- Log Viewer -->
       <div class="env-section">
-        <h3 class="dashboard-subtitle env-title">Recent Log (last 30 min); Last Update: <span id="display-last-updated">${
-            state.displayLogLastModified
-              ? new Date(state.displayLogLastModified).toLocaleString("en-US", {
-                  hour12: true,
-                  timeZone: "America/Chicago"
-                })
-              : "N/A"
-        }</span></h3>
-        <button id="toggleButton" class="btn-toggle">Show Recent Log</button>
+        <div class="log-viewer-header">
+          <h3 class="dashboard-subtitle env-title log-viewer-title">Recent Log (last 30 min); Last Update: <span id="display-last-updated">${
+              state.displayLogLastModified
+                ? new Date(state.displayLogLastModified).toLocaleString("en-US", {
+                    hour12: true,
+                    timeZone: "America/Chicago"
+                  })
+                : "N/A"
+          }</span></h3>
+          <button id="toggleButton" class="btn-toggle log-toggle-button">Show Recent Log</button>
+        </div>
         <div id="fullContent" class="content-section">
           <pre></pre>
         </div>


### PR DESCRIPTION
### Summary of Changes:
Implemented the memory-stability plan across the log pipeline, graph caches, and dashboard.

[services/gdrive.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/) now streams Drive files into a bounded recent-snippet collector, keeps only the newest 30-minute window with 10,000 line / 2 MiB safety caps, falls back to the last 5,000 lines when timestamps are missing, and skips downloads when the Drive file id and modified time have not changed. [services/state.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/) now tracks the cached display-log file id.
[services/graphs.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/) now owns capped pressure-point appends and display rebuilds, and both live polling and startup backfills were switched to that shared path in [services/polling.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/) and [services/supabase.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/). [routes.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/) now clears graph state through the same helper on experiment reset.
[views/dashboard.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/) now labels the panel as a recent log, loads cached /raw content immediately, restores the open state from session storage without forcing /refresh-display, and no longer blocks the panel on a fresh Drive fetch.
Verified with node --test --test-isolation=none test\polling.test.js in [test/polling.test.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/).

The recent-log section now uses its own explicit header row in [views/dashboard.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/brand/.vscode/extensions/openai.chatgpt-26.324.21329-win32-x64/webview/), which should make the full visible button area clickable

Origin plan for fixing:
# Stabilize Memory Use for Display Logs and Pressure Caches

## Summary
- Fix the primary OOM path by replacing the current full-file display-log refresh with a bounded recent-snippet pipeline.
- Keep the log viewer aligned with your intended UX: the button shows a cached recent chunk immediately, defined as the most recent 30 minutes when timestamps are parseable.
- Stop long-lived memory growth in both pressure graphs by enforcing their existing in-memory caps without doing a larger long-term-history redesign.

## Key Changes
- Display-log pipeline
  - Replace the current "download all lines, reverse everything, then trim" flow with a streaming extractor that only keeps a bounded suffix while reading.
  - Primary retention rule: keep lines whose parsed timestamp falls within 30 minutes of the newest parseable timestamp seen in the file.
  - Safety bounds: never retain more than `10,000` lines or `2 MiB` of cached text; if no usable timestamps are found, fall back to the last `5,000` lines.
  - Keep the snippet newest-first for the UI, but only reverse the bounded retained window, never the whole file.
  - Cache only the recent snippet to the existing local cache file and shared metadata; skip the download entirely when the newest Drive file id and modified time match the cached values.
  - Keep the startup warm-up and 60-second background refresh cadence. `GET /refresh-display` stays available, but it refreshes the snippet cache instead of a whole-log cache.

- Log viewer behavior
  - Change the dashboard toggle so opening the panel fetches cached `/raw` content immediately and does not call `/refresh-display` first.
  - Preserve the current expanded/collapsed session behavior, but when the page restores with the panel open it should load only the cached snippet.
  - Update the UI copy from full-log language to recent-snippet language, for example `Show Recent Log` and `Recent Log (last 30 min)`.

- Pressure graph memory caps
  - Introduce one shared pressure-point append helper used by both backfill and live polling paths.
  - That helper should append the new point, enforce `maxDataPoints`, and keep display arrays valid from the same retained raw window.
  - When a cap is exceeded, trim raw arrays with whole-array slicing to the newest `maxDataPoints`, reset downsampling state, and rebuild display arrays from the retained data.
  - Apply this to both pressure graphs using the current limits: `30_000` for short-term and `100_000` for long-term.
  - Do not change the broader long-term data-source design in this pass; this is a bounded-memory fix only.

## API / Interface Notes
- `/raw` remains `text/plain`, but its semantics change from "full reversed log" to "cached recent log snippet".
- `/refresh-display` remains available, but it refreshes the recent snippet cache rather than a full-log cache.
- No new public endpoint is required.

## Test Plan
- Large display-log refreshes never build an in-memory array of the full file and never reverse the full file before trimming.
- Timestamped logs return only the most recent 30-minute window, newest-first in the cached snippet.
- Logs with missing or unparseable timestamps fall back to the last `5,000` lines and still respect the `10,000`-line / `2 MiB` safety bounds.
- Refresh is skipped when the Drive file is unchanged.
- Opening the log viewer requests only `/raw` and does not block on `/refresh-display`.
- Short-term pressure graph remains capped at `30,000` raw points after extended live polling and still reports correct display metadata.
- Long-term pressure graph remains capped at `100,000` raw points after extended polling and still exposes the latest point correctly.

## Assumptions
- Source display logs are written oldest-to-newest, and enough lines in the desired recent window contain parseable timestamps to make the 30-minute filter useful.
- Showing cached content immediately is preferred over forcing a fresh Drive fetch when the panel opens.
- This plan intentionally avoids a larger "true all-time" redesign for the long-term graph and focuses on removing the memory-growth risk with the existing in-memory limits.
