### PR TITLE
Refactor/ccs graphs layout

### DIFF
--- a/views/dashboard.js
+++ b/views/dashboard.js
@@ -448,7 +448,7 @@ function renderDashboard(opts) {
           border-radius: 15px;
           padding: 10px;
           margin: 14px auto;
-          width: 98%;
+          width: 90%;
         }
 
         #ccs-charts-section .chart-container { margin: 0; width: 100%; }
@@ -461,22 +461,16 @@ function renderDashboard(opts) {
         }
 
         #ccs-charts-section .chart {
-          min-height: 180px;
           height: auto;
         }
 
         #ccs-charts-section {
           display: grid;
-          grid-template-columns: repeat(3, 1fr);
+          grid-template-columns: 1fr;
           gap: 10px;
-          width: 98%;
+          width: 90%;
           margin: 10px auto;
           box-sizing: border-box;
-        }
-        @media (max-width: 900px) {
-          #ccs-charts-section {
-            grid-template-columns: 1fr;
-          }
         }
 
         .chart-title {
@@ -699,7 +693,7 @@ function renderDashboard(opts) {
 
       <div id="chart-root-2"></div>
       <div id="pressure-chart-section">
-        <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 10px 8px; width: 98%; margin: 0 auto 0 auto;">
+        <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 10px 8px; width: 90%; margin: 0 auto 0 auto;">
           <span id="pressure-chart-label" style="color:#94a3b8; font-size:14px;">
             Short-Term (Last 24h, ~3s source data, downsampled for display)
           </span>
@@ -707,7 +701,7 @@ function renderDashboard(opts) {
             Switch to Historical View
           </button>
         </div>
-        <div id="pressure-chart-status" class="chart-info-text" style="width:98%; margin:0 auto 6px auto; text-align:left; color:#94a3b8;">
+        <div id="pressure-chart-status" class="chart-info-text" style="width:90%; margin:0 auto 6px auto; text-align:left; color:#94a3b8;">
           ${formatPressureChartStatus(shortTermChartMeta)}
         </div>
         <div id="chart-root-3" style="margin-top: 0;"></div>
@@ -898,7 +892,7 @@ function renderDashboard(opts) {
 
           const uplot = new uPlot({
             width: wrapper.clientWidth,
-            height: 180,
+            height: 250,
             series: [
               {},
               {
@@ -935,7 +929,7 @@ function renderDashboard(opts) {
           }, data, chartEl);
 
           window.addEventListener('resize', () => {
-            uplot.setSize({ width: wrapper.clientWidth, height: 180 });
+            uplot.setSize({ width: wrapper.clientWidth, height: 250 });
           });
 
           chartEl.ondblclick = () => {

--- a/views/dashboard.js
+++ b/views/dashboard.js
@@ -718,7 +718,7 @@ function renderDashboard(opts) {
 
       <div id="chart-root-2"></div>
       <div id="pressure-chart-section">
-        <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 10px 8px; width: 98%; margin: 0 auto 0 auto;">
+        <div style="display: flex; justify-content: space-between; align-items: center; padding: 0 10px 8px; width: 90%; margin: 0 auto 0 auto;">
           <span id="pressure-chart-label" style="color:#94a3b8; font-size:14px;">
             Short-Term (Last 24h, ~3s source data, downsampled for display)
           </span>

--- a/views/dashboard.js
+++ b/views/dashboard.js
@@ -451,7 +451,7 @@ function renderDashboard(opts) {
           width: 90%;
         }
 
-        #ccs-charts-section .chart-container { margin: 0; width: 100%; }
+        #ccs-charts-section .chart-container { margin: 10px auto; }
 
         .chart {
           position: relative;
@@ -465,12 +465,7 @@ function renderDashboard(opts) {
         }
 
         #ccs-charts-section {
-          display: grid;
-          grid-template-columns: 1fr;
-          gap: 10px;
-          width: 90%;
-          margin: 10px auto;
-          box-sizing: border-box;
+          margin: 10px 0;
         }
 
         .chart-title {


### PR DESCRIPTION
The CCS temperature graphs were rendering too wide, causing horizontal scrolling on the dashboard. This PR fixes the layout so all three CCS graphs are consistently sized and centered, matching the alignment of the pressure graph and other dashboard components. The graphs are also now stacked vertically instead of displayed side by side.